### PR TITLE
Add `TransferCreationService`

### DIFF
--- a/best-practices/01-service-ception/src/main/java/com/github/jarvvski/wisestart/demo/application/TransferCreationService.java
+++ b/best-practices/01-service-ception/src/main/java/com/github/jarvvski/wisestart/demo/application/TransferCreationService.java
@@ -1,0 +1,33 @@
+package com.github.jarvvski.wisestart.demo.application;
+
+import com.github.jarvvski.wisestart.demo.domain.Transfer;
+import com.github.jarvvski.wisestart.demo.domain.TransferId;
+import com.github.jarvvski.wisestart.demo.domain.TransferRepository;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TransferCreationService {
+
+    private final TransferRepository transferRepository;
+
+    public TransferCreatedResponse createTransfer(CreateTransferCommand createTransferCommand) {
+        final var transfer = Transfer.builder()
+            .id(TransferId.next())
+            .money(createTransferCommand.money())
+            .source(createTransferCommand.source())
+            .recipient(createTransferCommand.recipient())
+            .creationDate(Instant.now())
+            .lastUpdatedDate(Instant.now())
+            .build();
+
+        transferRepository.save(transfer);
+
+        return transfer.toCreatedResponse();
+    }
+
+}

--- a/best-practices/01-service-ception/src/main/java/com/github/jarvvski/wisestart/demo/infrastructure/PublicTransferControllerV1.java
+++ b/best-practices/01-service-ception/src/main/java/com/github/jarvvski/wisestart/demo/infrastructure/PublicTransferControllerV1.java
@@ -2,6 +2,7 @@ package com.github.jarvvski.wisestart.demo.infrastructure;
 
 import com.github.jarvvski.wisestart.demo.application.CreateTransferCommand;
 import com.github.jarvvski.wisestart.demo.application.TransferCreatedResponse;
+import com.github.jarvvski.wisestart.demo.application.TransferCreationService;
 import com.github.jarvvski.wisestart.demo.domain.Transfer;
 import com.github.jarvvski.wisestart.demo.domain.TransferId;
 import com.github.jarvvski.wisestart.demo.domain.TransferRepository;
@@ -23,23 +24,15 @@ import java.util.UUID;
 @Slf4j
 public class PublicTransferControllerV1 {
 
-    private final TransferRepository transferRepository;
+    private final TransferCreationService transferCreationService;
 
     @PostMapping("/create")
     public ResponseEntity<TransferCreatedResponse> createTransfer(@RequestBody CreateTransferCommand createTransferCommand) {
         log.info("Creating transfer via http call");
-        final var transfer = Transfer.builder()
-            .id(TransferId.next())
-            .money(createTransferCommand.money())
-            .source(createTransferCommand.source())
-            .recipient(createTransferCommand.recipient())
-            .creationDate(Instant.now())
-            .lastUpdatedDate(Instant.now())
-            .build();
-        transferRepository.save(transfer);
 
+        final var response = transferCreationService.createTransfer(createTransferCommand);
         return ResponseEntity.created(
-                URI.create("/public/v1/transfer" + transfer.getId().toString())
-            ).body(transfer.toCreatedResponse());
+                URI.create("/public/v1/transfer" + response.id())
+            ).body(response);
     }
 }


### PR DESCRIPTION
## Context

Transfer Creation logic is currently duplicated in `PublicTransferControllerV1` and `KafkaTransferMessaging`.

### Changes

Introduced a new `TransferCreationService`, which is used by `PublicTransferControllerV1` and `KafkaTransferMessaging`, to keep logic in one place, and out of the Infra layer.
